### PR TITLE
Use env to determine bash location

### DIFF
--- a/jekyll_scripts/new_post
+++ b/jekyll_scripts/new_post
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd _posts
 DATE=`date +%Y-%m-%d`


### PR DESCRIPTION
Not all systems have bash accessible at /bin/bash.
For example, on a FreeBSD system it is normally at /usr/local/bin/bash, if it is installed (due it not being in the base system)
By using env to find bash, the script becomes more cross platform.
